### PR TITLE
Made a configuration and view change

### DIFF
--- a/announcements/views.py
+++ b/announcements/views.py
@@ -211,7 +211,7 @@ class KeywordListAPIView(APIView):
         s = request.query_params.get('s', None)
         keywords = None
         if s is not None:
-            keywords = Tag.objects.filter(name__contains=s)
+            keywords = Tag.objects.filter(name__icontains=s)
         else:
             keywords = Tag.objects.all()[:10]
 

--- a/settings.py
+++ b/settings.py
@@ -116,6 +116,8 @@ REST_FRAMEWORK = {
     )
 }
 
+# Taggit settings
+TAGGIT_CASE_INSENSITIVE = True
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.10/topics/i18n/


### PR DESCRIPTION
Bug Fixes:
* Added the `TAGGIT_CASE_INSENSITIVE` setting and set it true to ensure tags are looked up and added in a case insensitive manner.
* Updated the keyword lookup view used by the typeahead to be case insensitive. 