### PR TITLE
Migration Updates

### DIFF
--- a/announcements/migrations/0006_collation_charsets.py
+++ b/announcements/migrations/0006_collation_charsets.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-import logging
-
 def alter_collation(character_set, collation, scheme_editor):
     with scheme_editor.connection.cursor() as cursor:
         # Set collation and character set defaults for database

--- a/announcements/migrations/0006_collation_charsets.py
+++ b/announcements/migrations/0006_collation_charsets.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
+import logging
+
 def alter_collation(character_set, collation, scheme_editor):
     with scheme_editor.connection.cursor() as cursor:
         # Set collation and character set defaults for database
@@ -20,18 +22,25 @@ def alter_collation(character_set, collation, scheme_editor):
             )
 
 def alter_collation_forwards(apps, schema_editor):
-	'''
-	Sets *collation* and *character_set* for a database and its tables.
-	Also converts data in the tables if necessary.
-	'''
-	return alter_collation('utf8mb4', 'utf8mb4_general_ci', schema_editor)
+    '''
+    Sets *collation* and *character_set* for a database and its tables.
+    Also converts data in the tables if necessary.
+    '''
+    if schema_editor.connection.vendor != 'mysql':
+        return
+
+    return alter_collation('utf8mb4', 'utf8mb4_general_ci', schema_editor)
 
 
 def alter_collation_reverse(apps, schema_editor):
-	return alter_collation('latin1', 'latin1_swedish_ci', schema_editor)
+    if schema_editor.connection.vendor != 'mysql':
+        return
+
+    return alter_collation('latin1', 'latin1_swedish_ci', schema_editor)
 
 
 class Migration(migrations.Migration):
+
 
     dependencies = [
         ('announcements', '0005_auto_20180322_1505'),

--- a/announcements/migrations/0007_alter_announcement_id_alter_audience_id_and_more.py
+++ b/announcements/migrations/0007_alter_announcement_id_alter_audience_id_and_more.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('announcements', '0005_auto_20180322_1505'),
+        ('announcements', '0006_collation_charsets'),
     ]
 
     operations = [


### PR DESCRIPTION
Bug Fixes:
* Updated migration order to ensure one migration runs after another and avoids duplicate IDs on migration, which is not allowed.
* Ensure that MySQL specific migration code only runs on MySQL.