### PR TITLE
CSRF Trusted Origin Setting

### DIFF
--- a/.env.templ
+++ b/.env.templ
@@ -46,6 +46,9 @@
 # Secure Proxy SSL Header: Determines what header should be set when connection is secure
 # SECURE_PROXY_SSL_HEADER='HTTP_X_FORWARDED_PROTO=https'
 
+# A list of trusted origins for CSRF requests
+# CSRF_TRUSTED_ORIGINS=http://localhost:8000
+
 # LDAP Host: The host of the ldap server
 # LDAP_NET_HOST=ldaps://you.ldap.com
 

--- a/settings.py
+++ b/settings.py
@@ -57,6 +57,7 @@ FORCE_SCRIPT_NAME = env('FORCE_SCRIPT_NAME', str, default='/')
 CSRF_COOKIE_PATH = env('CSRF_COOKIE_PATH', str, default='/')
 CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', bool, default=False) # Should be set to true in production environments
 CSRF_COOKIE_SECURE = env('CSRF_COOKIE_SECURE', bool, default=False) # Should be set to true in production environments
+CSRF_TRUSTED_ORIGINS = env('CSRF_TRUSTED_ORIGINS', list, default=['http://localhost:8000'])
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # NET Domain LDAP CONFIG


### PR DESCRIPTION
Bug Fixes:
* Django 4.0+ requires a `CSRF_TRUSTED_ORIGINS` setting to be explicitly set to allow CSRF functionality (which is used for logins and forms throughout the site). This adds the setting and allows it to be configured in the `.env` file.